### PR TITLE
Version 1.0.6 - Use Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,12 @@ const opts = {
   'segment': "status", // {String} The segment to get status from. Required for multi-segment flags. For single segment flag skip this.
   'key': "key_example" // {String} An identifier to be a key to associate the status with. This is used on flag which status you need to be consistent after the first random generated. For always random status behavior skip this.
 };
-const callback = function(error, data, response) {
-  if (error) {
-    console.error(error);
-  } else {
-    console.log('Flag status: ' + data.value);
-  }
-};
+api.getStatus(ownerId, flagId, opts).then(function(data) {
+  console.log('API called successfully. Returned data: ' + data);
+}, function(error) {
+  console.error(error);
+});
 
-api.getStatus(ownerId, flagId, opts, callback);
 
 ```
 

--- a/docs/PublicApi.md
+++ b/docs/PublicApi.md
@@ -34,13 +34,12 @@ let opts = {
   'segment': "segment_example", // String | The segment to get status from. Required for multi-segment flags. For single segment flag skip this.
   'key': "key_example" // String | An identifier to be a key to associate the status with. This is used on flag which status you need to be consistent after the first random generated. For always random status behavior skip this.
 };
-apiInstance.getStatus(ownerId, flagId, opts, (error, data, response) => {
-  if (error) {
-    console.error(error);
-  } else {
-    console.log('API called successfully. Returned data: ' + data);
-  }
+apiInstance.getStatus(ownerId, flagId, opts).then((data) => {
+  console.log('API called successfully. Returned data: ' + data);
+}, (error) => {
+  console.error(error);
 });
+
 ```
 
 ### Parameters
@@ -64,5 +63,5 @@ Name | Type | Description  | Notes
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: text/plain, application/json
+- **Accept**: text/html, application/json
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteflags-nodejs-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Remote Flags nodejs client. Access Public API for integration withRemote Flags.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -17,7 +17,7 @@ import querystring from "querystring";
 
 /**
 * @module ApiClient
-* @version 1.0.0
+* @version 1.0.6
 */
 
 /**
@@ -55,7 +55,7 @@ class ApiClient {
          * @default {}
          */
         this.defaultHeaders = {
-            'User-Agent': 'OpenAPI-Generator/1.0.0/Javascript'
+            'User-Agent': 'OpenAPI-Generator/1.0.6/Javascript'
         };
 
         /**
@@ -368,13 +368,6 @@ class ApiClient {
         return ApiClient.convertToType(data, returnType);
     }
 
-   /**
-    * Callback function to receive the result of the operation.
-    * @callback module:ApiClient~callApiCallback
-    * @param {String} error Error message, if any.
-    * @param data The data returned by the service call.
-    * @param {String} response The complete HTTP response.
-    */
 
    /**
     * Invokes the REST service using the supplied settings and parameters.
@@ -391,12 +384,11 @@ class ApiClient {
     * @param {(String|Array|ObjectFunction)} returnType The required type to return; can be a string for simple types or the
     * constructor for a complex type.
     * @param {String} apiBasePath base path defined in the operation/path level to override the default one
-    * @param {module:ApiClient~callApiCallback} callback The callback function.
-    * @returns {Object} The SuperAgent request object.
+    * @returns {Promise} A {@link https://www.promisejs.org/|Promise} object.
     */
     callApi(path, httpMethod, pathParams,
         queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
-        returnType, apiBasePath, callback) {
+        returnType, apiBasePath) {
 
         var url = this.buildUrl(path, pathParams, apiBasePath);
         var request = superagent(httpMethod, url);
@@ -485,25 +477,34 @@ class ApiClient {
             }
         }
 
-        request.end((error, response) => {
-            if (callback) {
-                var data = null;
-                if (!error) {
+        return new Promise((resolve, reject) => {
+            request.end((error, response) => {
+                if (error) {
+                    var err = {};
+                    if (response) {
+                        err.status = response.status;
+                        err.statusText = response.statusText;
+                        err.body = response.body;
+                        err.response = response;
+                    }
+                    err.error = error;
+
+                    reject(err);
+                } else {
                     try {
-                        data = this.deserialize(response, returnType);
+                        var data = this.deserialize(response, returnType);
                         if (this.enableCookies && typeof window === 'undefined'){
                             this.agent._saveCookies(response);
                         }
+
+                        resolve({data, response});
                     } catch (err) {
-                        error = err;
+                        reject(err);
                     }
                 }
-
-                callback(error, data, response);
-            }
+            });
         });
 
-        return request;
     }
 
     /**

--- a/src/com.remoteflags.api/PublicApi.js
+++ b/src/com.remoteflags.api/PublicApi.js
@@ -18,7 +18,7 @@ import Status from '../com.remoteflags.model/Status';
 /**
 * Public service.
 * @module com.remoteflags.api/PublicApi
-* @version 1.0.0
+* @version 1.0.6
 */
 export default class PublicApi {
 
@@ -34,13 +34,6 @@ export default class PublicApi {
     }
 
 
-    /**
-     * Callback function to receive the result of the getStatus operation.
-     * @callback module:com.remoteflags.api/PublicApi~getStatusCallback
-     * @param {String} error Error message, if any.
-     * @param {module:com.remoteflags.model/Status} data The data returned by the service call.
-     * @param {String} response The complete HTTP response.
-     */
 
     /**
      * Get a flag status.
@@ -50,10 +43,9 @@ export default class PublicApi {
      * @param {Object} opts Optional parameters
      * @param {String} opts.segment The segment to get status from. Required for multi-segment flags. For single segment flag skip this.
      * @param {String} opts.key An identifier to be a key to associate the status with. This is used on flag which status you need to be consistent after the first random generated. For always random status behavior skip this.
-     * @param {module:com.remoteflags.api/PublicApi~getStatusCallback} callback The callback function, accepting three arguments: error, data, response
-     * data is of type: {@link module:com.remoteflags.model/Status}
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:com.remoteflags.model/Status} and HTTP response
      */
-    getStatus(ownerId, flagId, opts, callback) {
+    getStatusWithHttpInfo(ownerId, flagId, opts) {
       opts = opts || {};
       let postBody = null;
       // verify the required parameter 'ownerId' is set
@@ -80,13 +72,30 @@ export default class PublicApi {
 
       let authNames = ['RemoteFlagsAuthorizer'];
       let contentTypes = [];
-      let accepts = ['text/plain', 'application/json'];
+      let accepts = ['text/html', 'application/json'];
       let returnType = Status;
       return this.apiClient.callApi(
         '/status/owner/{ownerId}/flag/{flagId}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, null, callback
+        authNames, contentTypes, accepts, returnType, null
       );
+    }
+
+    /**
+     * Get a flag status.
+     * Use this operation to get a flag status from remoteflags.
+     * @param {String} ownerId OwnerID to fetch status for
+     * @param {String} flagId FlagId to fetch status for
+     * @param {Object} opts Optional parameters
+     * @param {String} opts.segment The segment to get status from. Required for multi-segment flags. For single segment flag skip this.
+     * @param {String} opts.key An identifier to be a key to associate the status with. This is used on flag which status you need to be consistent after the first random generated. For always random status behavior skip this.
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:com.remoteflags.model/Status}
+     */
+    getStatus(ownerId, flagId, opts) {
+      return this.getStatusWithHttpInfo(ownerId, flagId, opts)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
     }
 
 

--- a/src/com.remoteflags.model/Status.js
+++ b/src/com.remoteflags.model/Status.js
@@ -16,7 +16,7 @@ import ApiClient from '../ApiClient';
 /**
  * The Status model module.
  * @module com.remoteflags.model/Status
- * @version 1.0.0
+ * @version 1.0.6
  */
 class Status {
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ import PublicApi from './com.remoteflags.api/PublicApi';
 * </pre>
 * </p>
 * @module index
-* @version 1.0.0
+* @version 1.0.6
 */
 export {
     /**


### PR DESCRIPTION
### Notes
 - Version 1.0.6 
  - Use Promises instead of callbacks. 
  - Use ```text/html``` for error responses